### PR TITLE
update release paths to not include versions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,3 +18,11 @@ builds:
     main: cmd/plugin/main.go
     ldflags: -s -w
       -X github.com/{{ .Owner }}/{{ .Repo }}/pkg/version.version=
+archives:
+  - id: {{ .PluginName }}
+    builds:
+    - {{ .PluginName }}
+    name_template: {{ `"{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"` }}
+    format_overrides:
+    - goos: windows
+      format: zip

--- a/deploy/krew/plugin.yaml
+++ b/deploy/krew/plugin.yaml
@@ -9,7 +9,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_0.1.0_linux_amd64-0.1.0.tar.gz
+    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_linux_amd64.tar.gz
     sha256: ""
     files:
     - from: "./{{ .PluginName }}"
@@ -19,7 +19,7 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_0.3.1_darwin_amd64-0.1.0.tar.gz
+    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_darwin_amd64.tar.gz
     sha256: ""
     files:
     - from: "./{{ .PluginName }}"
@@ -29,7 +29,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_0.3.1_windows_amd64-0.1.0.zip
+    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_windows_amd64.zip
     sha256: ""
     files:
     - from: "/{{ .PluginName }}.exe"


### PR DESCRIPTION
Resolves #1 

This PR customizes the archive filenames produced by GoReleaser to not include the version of the release and updates paths within `deploy/krew/plugin.yaml` to refer to these versionless paths.