### PR TITLE
update README.md to use a message when tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make bin
 To create a new release of your plugin, create and push a tag.
 
 ```shell
-git tag v0.1.0
+git tag v0.1.0 -m 'initial release'
 git push --tags
 ```
 


### PR DESCRIPTION
goreleaser needs a message to generate the changelog as expected.

Unless a tag is done with an explicit message all commits will be shown in the chagelog, nut just the ones from the previous release.
An example can be seen in https://github.com/bergerx/kubectl-status/releases, see the generated changelogs from v0.1.1 to v0.3.0.

The changelogs are now as expected only after i started to use `git tag` with the `-m` flag.