### PR TITLE
Dev/update golang

### DIFF
--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/{{ .Owner }}/{{ .Repo }}/pkg/logger"
 	"github.com/{{ .Owner }}/{{ .Repo }}/pkg/plugin"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tj/go-spin"
@@ -59,7 +59,7 @@ func RootCmd() *cobra.Command {
 			}()
 
 			if err := plugin.RunPlugin(KubernetesConfigFlags, namespaceName); err != nil {
-				return errors.Cause(err)
+				return errors.Unwrap(err)
 			}
 
 			log.Info("")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicatedhq/krew-plugin-template
 
-go 1.12
+go 1.16
 
 require (
 	github.com/Microsoft/go-winio v0.4.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/onsi/gomega v1.5.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/smartystreets/assertions v0.0.0-20190401211740-f487f9de1cd3 // indirect
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/viper v1.4.0

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
@@ -12,17 +11,17 @@ import (
 func RunPlugin(configFlags *genericclioptions.ConfigFlags, outputCh chan string) error {
 	config, err := configFlags.ToRESTConfig()
 	if err != nil {
-		return errors.Wrap(err, "failed to read kubeconfig")
+		return fmt.Errorf("failed to read kubeconfig: %w", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return errors.Wrap(err, "failed to create clientset")
+		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 
 	namespaces, err := clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
-		return errors.Wrap(err, "failed to list namespaces")
+		return fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
 	for _, namespace := range namespaces.Items {

--- a/setup/gomod.go
+++ b/setup/gomod.go
@@ -5,14 +5,12 @@ import (
 	"io/ioutil"
 	"path"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func renderGoMod(templateContext TemplateContext) error {
 	input, err := ioutil.ReadFile(path.Join("..", "go.mod"))
 	if err != nil {
-		return errors.Wrap(err, "failed to read go.mod")
+		return fmt.Errorf("failed to read go.mod: %w", err)
 	}
 
 	lines := strings.Split(string(input), "\n")
@@ -22,7 +20,7 @@ func renderGoMod(templateContext TemplateContext) error {
 	output := strings.Join(lines, "\n")
 	err = ioutil.WriteFile(path.Join("..", "go.mod"), []byte(output), 0644)
 	if err != nil {
-		return errors.Wrap(err, "failed to write go.mod")
+		return fmt.Errorf("failed to write go.mod: %w", err)
 	}
 
 	return nil

--- a/setup/main.go
+++ b/setup/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -8,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/manifoldco/promptui"
-	"github.com/pkg/errors"
 	"github.com/replicatedhq/krew-plugin-template/pkg/logger"
 )
 
@@ -21,19 +21,19 @@ type TemplateContext struct {
 func main() {
 	owner, err := promptForOwner()
 	if err != nil {
-		fmt.Printf("%v\n", errors.Cause(err))
+		fmt.Printf("%v\n", errors.Unwrap(err))
 		os.Exit(1)
 	}
 
 	repo, err := promptForRepo()
 	if err != nil {
-		fmt.Printf("%v\n", errors.Cause(err))
+		fmt.Printf("%v\n", errors.Unwrap(err))
 		os.Exit(1)
 	}
 
 	pluginName, err := promptForPluginName()
 	if err != nil {
-		fmt.Printf("%v\n", errors.Cause(err))
+		fmt.Printf("%v\n", errors.Unwrap(err))
 		os.Exit(1)
 	}
 
@@ -46,25 +46,25 @@ func main() {
 	log := logger.NewLogger()
 	log.Info("Updating README")
 	if err := renderReadme(templateContext); err != nil {
-		fmt.Printf("%v\n", errors.Cause(err))
+		fmt.Printf("%v\n", errors.Unwrap(err))
 		os.Exit(1)
 	}
 
 	log.Info("Updating sample code with names")
 	if err := renderTemplates(templateContext); err != nil {
-		fmt.Printf("%v\n", errors.Cause(err))
+		fmt.Printf("%v\n", errors.Unwrap(err))
 		os.Exit(1)
 	}
 
 	log.Info("Updating go.mod")
 	if err := renderGoMod(templateContext); err != nil {
-		fmt.Printf("%v\n", errors.Cause(err))
+		fmt.Printf("%v\n", errors.Unwrap(err))
 		os.Exit(1)
 	}
 
 	log.Info("Removing the setup application")
 	if err := os.RemoveAll(path.Join("..", "setup")); err != nil {
-		fmt.Printf("%v\n", errors.Cause(err))
+		fmt.Printf("%v\n", errors.Unwrap(err))
 		os.Exit(1)
 	}
 
@@ -76,7 +76,7 @@ func main() {
 func promptForOwner() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get working dir")
+		return "", fmt.Errorf("failed to get working dir: %w", err)
 	}
 
 	pathParts := strings.Split(filepath.Dir(cwd), string(os.PathSeparator))
@@ -96,7 +96,7 @@ func promptForOwner() (string, error) {
 
 	result, err := prompt.Run()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to prompt for github owner")
+		return "", fmt.Errorf("failed to prompt for github owner: %w", err)
 	}
 
 	return result, nil
@@ -105,14 +105,14 @@ func promptForOwner() (string, error) {
 func promptForRepo() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get working dir")
+		return "", fmt.Errorf("failed to get working dir: %w", err)
 	}
 
 	pathParts := strings.Split(filepath.Dir(cwd), string(os.PathSeparator))
 
 	validate := func(input string) error {
 		if len(input) == 0 {
-			return errors.New("Invalid")
+			return errors.New("invalid")
 		}
 		return nil
 	}
@@ -125,7 +125,7 @@ func promptForRepo() (string, error) {
 
 	result, err := prompt.Run()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to prompt for github repo")
+		return "", fmt.Errorf("failed to prompt for github repo: %w", err)
 	}
 
 	return result, nil
@@ -134,7 +134,7 @@ func promptForRepo() (string, error) {
 func promptForPluginName() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get working dir")
+		return "", fmt.Errorf("failed to get working dir: %w", err)
 	}
 
 	pathParts := strings.Split(filepath.Dir(cwd), string(os.PathSeparator))
@@ -154,7 +154,7 @@ func promptForPluginName() (string, error) {
 
 	result, err := prompt.Run()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to prompt for plugin name")
+		return "", fmt.Errorf("failed to prompt for plugin name: %w", err)
 	}
 
 	return result, nil

--- a/setup/readme.go
+++ b/setup/readme.go
@@ -1,21 +1,20 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
-
-	"github.com/pkg/errors"
 )
 
 func renderReadme(templateContext TemplateContext) error {
 	input, err := ioutil.ReadFile(path.Join("hack", "README.txt"))
 	if err != nil {
-		return errors.Wrap(err, "failed to read README.txt")
+		return fmt.Errorf("failed to read README.txt: %w", err)
 	}
 
 	err = ioutil.WriteFile(path.Join("..", "README.md"), input, 0644)
 	if err != nil {
-		return errors.Wrap(err, "failed to write README.md")
+		return fmt.Errorf("failed to write README.md: %w", err)
 	}
 
 	return nil

--- a/setup/templates.go
+++ b/setup/templates.go
@@ -1,12 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 func renderTemplates(templateContext TemplateContext) error {
@@ -43,7 +42,7 @@ func renderTemplates(templateContext TemplateContext) error {
 
 			fi, err := os.Stat(path)
 			if err != nil {
-				return errors.Wrap(err, "failed to read file info")
+				return fmt.Errorf("failed to read file info: %w", err)
 			}
 
 			if fi.IsDir() {
@@ -52,22 +51,22 @@ func renderTemplates(templateContext TemplateContext) error {
 
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {
-				return errors.Wrap(err, "failed to parse template")
+				return fmt.Errorf("failed to parse template: %w", err)
 			}
 
 			f, err := os.Create(path)
 			if err != nil {
-				return errors.Wrap(err, "failed to create file")
+				return fmt.Errorf("failed to create file: %w", err)
 			}
 
 			if err := tmpl.Execute(f, templateContext); err != nil {
-				return errors.Wrap(err, "failed to execute template")
+				return fmt.Errorf("failed to execute template: %w", err)
 			}
 
 			return nil
 		})
 	if err != nil {
-		return errors.Wrap(err, "failed to walk directory")
+		return fmt.Errorf("failed to walk directory: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Update golang to 1.16 (cf <https://golang.org/doc/devel/release>)
Use new `error` package instead of [`github.com/pkg/errors`](https://github.com/pkg/errors)