### PR TITLE
Add ARM64 architecture support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     - darwin
     goarch:
     - amd64
+    - arm64
     - "386"
     env:
       - CGO_ENABLED=0

--- a/deploy/krew/plugin.yaml
+++ b/deploy/krew/plugin.yaml
@@ -41,6 +41,42 @@ spec:
     - from: LICENSE
       to: "."
     bin: "{{ .PluginName }}.exe"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_linux_arm64.tar.gz
+    sha256: ""
+    files:
+    - from: "./{{ .PluginName }}"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "{{ .PluginName }}"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_darwin_arm64.tar.gz
+    sha256: ""
+    files:
+    - from: "./{{ .PluginName }}"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "{{ .PluginName }}"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: https://github.com/{{ .Owner }}/{{ .Repo }}/releases/download/v0.1.0/{{ .PluginName }}_windows_arm64.zip
+    sha256: ""
+    files:
+    - from: "/{{ .PluginName }}.exe"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "{{ .PluginName }}.exe"
   shortDescription: A new plugin
   homepage: https://github.com/{{ .Owner }}/{{ .Repo }}
   caveats: |


### PR DESCRIPTION
I found that a lot of krew plugins don't support the ARM64 architecture, used on Macs M1 for example. I guess it should be nice to add this support straight in the template to avoid this problem for future plugins.